### PR TITLE
Add support for fieldless enums in Scannable structs.

### DIFF
--- a/memscanner/Cargo.toml
+++ b/memscanner/Cargo.toml
@@ -10,6 +10,8 @@ edition = "2018"
 failure = "0.1.5"
 memscanner_derive = { version = "0.1.0", path = "../memscanner_derive" }
 nom = "5.0.0"
+num-traits = "0.2"
+num-derive = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 json5 = "0.2.5"
 syn = "1.0"

--- a/memscanner_derive/src/lib.rs
+++ b/memscanner_derive/src/lib.rs
@@ -5,44 +5,7 @@ use context::Context;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::spanned::Spanned;
-use syn::{parse_macro_input, DeriveInput, Type};
-
-// Returns a string representing the type of `ty.  Ensures that the
-// type is supported.
-fn get_type(ctx: &mut Context, ty: &Type) -> Option<&'static str> {
-    match ty {
-        Type::Path(p) => {
-            if p.path.is_ident("u8") {
-                Some("u8")
-            } else if p.path.is_ident("i16") {
-                Some("i16")
-            } else if p.path.is_ident("u16") {
-                Some("u16")
-            } else if p.path.is_ident("i32") {
-                Some("i32")
-            } else if p.path.is_ident("u32") {
-                Some("u32")
-            } else if p.path.is_ident("i64") {
-                Some("i64")
-            } else if p.path.is_ident("u64") {
-                Some("u64")
-            } else if p.path.is_ident("f32") {
-                Some("f32")
-            } else if p.path.is_ident("f64") {
-                Some("f64")
-            } else if p.path.is_ident("String") {
-                Some("string")
-            } else {
-                ctx.error_spanned_by(
-                    ty.clone(),
-                    format!("fields of type {:?} are unsupported.", &p),
-                );
-                None
-            }
-        }
-        _ => None,
-    }
-}
+use syn::{parse_macro_input, DeriveInput};
 
 fn scannable_impl(ctx: &mut Context, ast: &syn::DeriveInput) -> Option<TokenStream> {
     let data = match &ast.data {
@@ -56,21 +19,13 @@ fn scannable_impl(ctx: &mut Context, ast: &syn::DeriveInput) -> Option<TokenStre
     let name_str = syn::LitStr::new(&format!("{}", name), ast.ident.span());
 
     let mut offset_code = quote! {};
-    let mut addr_code = quote! {};
-    let mut read_code = quote! {};
-    let mut array_read_code = quote! {};
+    let mut read_code = quote! {use memscanner::ScannableValue;};
     for f in data.fields.iter() {
         let ident = f.ident.as_ref().unwrap();
 
         // Construct new identifiers.
         let ident_str = syn::LitStr::new(&format!("{}", ident), f.ty.span());
         let offset = format_ident!("{}_offset", ident);
-        let addr = format_ident!("{}_addr", ident);
-
-        let read = match get_type(ctx, &f.ty) {
-            Some(ty) => format_ident!("read_{}", ty),
-            None => continue,
-        };
 
         // The code that looks up the field's offset in the config and saves it.
         offset_code.extend(quote! {
@@ -81,25 +36,10 @@ fn scannable_impl(ctx: &mut Context, ast: &syn::DeriveInput) -> Option<TokenStre
                 .clone();
         });
 
-        // The code that calculates the field's address from the base address and
-        // field offset.
-        addr_code.extend(quote! {
-            let #addr = #offset + base_addr;
-        });
-
         // The code that reads the field's value and stores it in the object.
         read_code.extend(quote! {
-            obj.#ident = mem
-                .#read(#addr)
-                .ok_or(format_err!("can't read {}", #ident_str))?;
-        });
-
-        // The code that reads the field's value and stores it in an
-        // element in an array.
-        array_read_code.extend(quote! {
-            obj.#ident = cached_mem
-                .#read(#offset + base_addr)
-                .ok_or(format_err!("can't read {}", #ident_str))?;
+            obj.#ident.scan_val(mem, #offset + base_addr)
+                .map_err(|e| format_err!("can't read {}: {}", #ident_str, e))?;
         });
     }
 
@@ -107,6 +47,7 @@ fn scannable_impl(ctx: &mut Context, ast: &syn::DeriveInput) -> Option<TokenStre
     // store the config and offsets without leading new types.
     let code = quote! {
         impl memscanner::Scannable for #name {
+
             fn get_resolver(config: memscanner::TypeConfig) -> Result<Box<memscanner::Resolver<Self>>, failure::Error> {
                 #offset_code
 
@@ -118,7 +59,6 @@ fn scannable_impl(ctx: &mut Context, ast: &syn::DeriveInput) -> Option<TokenStre
                         .signature
                         .resolve(mem, start_addr, end_addr)
                         .ok_or(format_err! {"Can't resolve base address"})?;
-                    #addr_code
 
                     let scanner = move |obj: &mut Self, mem: &dyn memscanner::MemReader| -> Result<(), failure::Error> {
                         #read_code
@@ -178,7 +118,7 @@ fn scannable_impl(ctx: &mut Context, ast: &syn::DeriveInput) -> Option<TokenStre
                             update_mem_cache(mem, &mut cached_mem, base_addr, array_config.element_size)
                                 .map_err(|e| format_err!("{} of {}: ", i, #name_str))?;
 
-                            #array_read_code
+                            #read_code
                        }
                         Ok(())
                     };
@@ -199,6 +139,47 @@ pub fn scannable_macro(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
     let ast = parse_macro_input!(input as DeriveInput);
 
     let code = scannable_impl(&mut ctx, &ast);
+
+    match ctx.check() {
+        Ok(_) => match code {
+            Some(c) => {
+                //eprintln!("code: {}", c);
+                proc_macro::TokenStream::from(c)
+            }
+            None => {
+                return quote! {compile_error!("Unknown error with #[derive(Scannable)]")}.into()
+            }
+        },
+        Err(e) => Context::convert_to_compile_errors(e).into(),
+    }
+}
+
+fn scannable_enum_impl(ctx: &mut Context, ast: &syn::DeriveInput) -> Option<TokenStream> {
+    match &ast.data {
+        syn::Data::Enum(_) => (),
+        _ => {
+            ctx.error_spanned_by(ast, "#[derive(ScannableEnum)] is only supported on enums.");
+            return None;
+        }
+    };
+    let name = &ast.ident;
+    let code = quote! {
+        impl memscanner::ScannableValue<#name> for #name {
+            fn scan_val(&mut self, mem: &dyn memscanner::MemReader, addr: u64)
+            -> Result<(), Error> {
+                memscanner::macro_helpers::read_enum(self, mem, addr)
+            }
+        }
+    };
+    Some(code)
+}
+#[proc_macro_derive(ScannableEnum)]
+pub fn scannable_enum_macro(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let mut ctx = Context::new();
+    // Parse the input tokens into a syntax tree
+    let ast = parse_macro_input!(input as DeriveInput);
+
+    let code = scannable_enum_impl(&mut ctx, &ast);
 
     match ctx.check() {
         Ok(_) => match code {

--- a/memscanner_test/Cargo.toml
+++ b/memscanner_test/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2018"
 [dependencies]
 failure = "0.1.5"
 memscanner = {version = "0.1.0", path = "../memscanner"}
+num-traits = "0.2"
+num-derive = "0.2"
+serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This allows enums to be included in scannable structs through the
`#[derive(ScannableEnum)] trait.   A side effect of this change, the
ScannableValue trait is introduced for values that can be members
of a scannable struct.  This gets rid of an explicit allow list.